### PR TITLE
Add nodejs and npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10
 
 RUN apt update -qy && apt -y upgrade
-RUN apt -y install openjdk-11-jdk unzip curl
+RUN apt -y install openjdk-11-jdk unzip curl nodejs npm
 RUN apt clean
 RUN curl -o /tmp/cmd.zip http://cdn.sencha.com/cmd/7.2.0.56/no-jre/SenchaCmd-7.2.0.56-linux-amd64.sh.zip
 RUN unzip -qp /tmp/cmd.zip > /tmp/cmd


### PR DESCRIPTION
This adds nodejs and npm to the docker image, which is required for building the application (e.g. GeoStyler).

Debian 10 works with nodejs version 10.21.0.

@hwbllmnn please review