### PR TITLE
Fix modern build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10
 
 RUN apt update -qy && apt -y upgrade
-RUN apt -y install openjdk-11-jdk unzip curl nodejs npm
+RUN apt -y install openjdk-11-jdk unzip curl libssl-dev
 RUN apt clean
 RUN curl -o /tmp/cmd.zip http://cdn.sencha.com/cmd/7.2.0.56/no-jre/SenchaCmd-7.2.0.56-linux-amd64.sh.zip
 RUN unzip -qp /tmp/cmd.zip > /tmp/cmd
@@ -9,7 +9,25 @@ RUN mkdir -p /opt/Sencha
 RUN bash /tmp/cmd -q -dir /opt/Sencha
 RUN rm -rf /tmp/cmd*
 
+# install nodejs
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 12.16.0
+
+RUN mkdir -p $NVM_DIR
+
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.37.2/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
 RUN mkdir /src
 WORKDIR /src
 ENV PATH="/opt/Sencha:$PATH"
+# FIX for phnatomjs
+# https://github.com/ioBroker/ioBroker.phantomjs/issues/19#issuecomment-729653302
+ENV OPENSSL_CONF=/etc/ssl/
 CMD sencha app watch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:10
 
 RUN apt update -qy && apt -y upgrade
-RUN apt -y install openjdk-11-jdk unzip curl libssl-dev
+RUN apt -y install openjdk-11-jdk unzip curl
 RUN apt clean
 RUN curl -o /tmp/cmd.zip http://cdn.sencha.com/cmd/7.2.0.56/no-jre/SenchaCmd-7.2.0.56-linux-amd64.sh.zip
 RUN unzip -qp /tmp/cmd.zip > /tmp/cmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN mkdir /src
 WORKDIR /src
 ENV PATH="/opt/Sencha:$PATH"
-# FIX for phnatomjs
+# FIX for phantomjs
 # https://github.com/ioBroker/ioBroker.phantomjs/issues/19#issuecomment-729653302
 ENV OPENSSL_CONF=/etc/ssl/
 CMD sencha app watch


### PR DESCRIPTION
This actually fixes building the modern application by using nvm.

The previous fix did not work as debian seems to install incompatible `node` and `nvm` versions.

Also added a fix for phantom.js