### PR TITLE
Allow to build image with different Sencha CMD versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM debian:10
 
+ARG SENCHA_CMD_VERSION_FULL 7.2.0.56
+
 RUN apt update -qy && apt -y upgrade
 RUN apt -y install openjdk-11-jdk unzip curl
 RUN apt clean
-RUN curl -o /tmp/cmd.zip http://cdn.sencha.com/cmd/7.2.0.56/no-jre/SenchaCmd-7.2.0.56-linux-amd64.sh.zip
+RUN curl -o /tmp/cmd.zip http://cdn.sencha.com/cmd/${SENCHA_CMD_VERSION_FULL}/no-jre/SenchaCmd-${SENCHA_CMD_VERSION_FULL}-linux-amd64.sh.zip
 RUN unzip -qp /tmp/cmd.zip > /tmp/cmd
 RUN mkdir -p /opt/Sencha
 RUN bash /tmp/cmd -q -dir /opt/Sencha

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@
 This is best used from eg. a docker-compose file. For easiest use, you'll
 just need a volume mounted to `/src/` containing your ext application.
 When run, `sencha app watch` will be invoked in that folder.
+
+### Build for different Sencha CMD versions
+
+Per default the image offers Sencha CMD in version 7.2.0.56. In order to have an
+image with a different version you could use the `--build-arg` option while using `docker build`:
+
+```
+docker build -t sencha-cmd-docker:6.5.3.6 --build-arg SENCHA_CMD_VERSION_FULL=6.5.3.6 .
+```


### PR DESCRIPTION
This PR introduces a build argument `SENCHA_CMD_VERSION_FULL` in order to build an image with a different Sencha CMD version than the default one (7.2.0.56).